### PR TITLE
Chore: the workflow now run on `Java 21` now... 😏

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
-          java-version: "17"
+          distribution: "jetbrains"
+          java-version: "21"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
# Changes Made

- Update the workflow to run the job on jetbrain runtime.
- Update the workflow to build app on 21 version.

