### PR TITLE
Chore: Add Java setup for CodeQL workflow

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -9,6 +9,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '**.yml'
+      - 'docs/**'
 
   release:
     types:
@@ -40,6 +45,7 @@ jobs:
         with:
           distribution: "jetbrains"
           java-version: "21"
+          cache: 'gradle'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -59,12 +65,12 @@ jobs:
           if [[ "${{ github.event_name }}" == "release" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "Triggered by release or manual dispatch. Building release variant."
             BUILD_VARIANT="release"
-            ./gradlew assembleRelease
+            ./gradlew assembleRelease --no-daemon
             APK_PATH=app/build/outputs/apk/release/app-universal-release-unsigned.apk
           else
             echo "Triggered by push to 'main' branch. Building staging variant."
             BUILD_VARIANT="staging"
-            ./gradlew assembleStaging
+            ./gradlew assembleStaging --no-daemon
             APK_PATH=app/build/outputs/apk/staging/app-universal-staging.apk
           fi
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@
 name: "CodeQL"
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -56,6 +59,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "jetbrains"
+          java-version: "21"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,15 @@
 name: "CodeQL"
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - '**.yml'
+      - 'docs/**'
+  
   release:
     types: [created, published]
 
@@ -65,6 +68,7 @@ jobs:
         with:
           distribution: "jetbrains"
           java-version: "21"
+          cache: 'gradle'
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
# Changes Made

- Add a setup java step in Codeql workflow.
- Improve the process of trigger a workflow by ignore useless stuff.
- Add a gradle cache in workflow.

## Notes

Fix the issue that occur last time because codeql use Java 17 and we need Java 21. (https://github.com/PasscodesApp/Passcodes/actions/runs/19295347550)

