### PR TITLE
CI: update dependabot configuration for gradle

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      day: "sunday"
+    target-branch: "jeel-dev"
+    assignees:
+      - "JeelDobariya38"


### PR DESCRIPTION
# Changes Made

- dependabot now run on every sunday
- dependabot's pull request now target `jeel-dev` branch
- dependabot's pull request are now assigned to me (`JeelDobariya38`).