### PR TITLE
Feat: Data Recovery TroubleShooting & Keep Data Uninstall Prompt

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -85,6 +85,7 @@ const config: ExpoConfig = {
     ],
     "expo-status-bar",
     "expo-sqlite",
+    "./plugins/withHasFragileUserData.ts",
   ],
   experiments: {
     typedRoutes: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "passcodes",
       "version": "1.0.0",
       "dependencies": {
-        "@react-native-async-storage/async-storage": "2.2.0",
         "babel-plugin-inline-import": "^3.0.0",
         "drizzle-orm": "^0.45.2",
         "expo": "~56.0.11",
@@ -3581,18 +3580,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@react-native-async-storage/async-storage": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
-      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
-      "license": "MIT",
-      "dependencies": {
-        "merge-options": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -9181,15 +9168,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -10092,18 +10070,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/merge-options": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
-      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-obj": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/merge-stream": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "2.2.0",
     "babel-plugin-inline-import": "^3.0.0",
     "drizzle-orm": "^0.45.2",
     "expo": "~56.0.11",

--- a/plugins/withHasFragileUserData.ts
+++ b/plugins/withHasFragileUserData.ts
@@ -1,0 +1,22 @@
+import { ConfigPlugin, withAndroidManifest } from "@expo/config-plugins";
+
+const withHasFragileUserData: ConfigPlugin = (config) => {
+  return withAndroidManifest(config, async (modContext) => {
+    const androidManifest = modContext.modResults.manifest;
+
+    // Ensure the <application> tag array exists and has at least one entry
+    if (androidManifest.application && androidManifest.application.length > 0) {
+      const mainApplication = androidManifest.application[0];
+
+      // Inject the attribute safely into the attributes object ($)
+      mainApplication.$ = {
+        ...mainApplication.$,
+        "android:hasFragileUserData": "true",
+      };
+    }
+
+    return modContext;
+  });
+};
+
+export default withHasFragileUserData;

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -35,8 +35,12 @@ export default function RootLayout() {
   return (
     <Suspense fallback={<ActivityIndicator size="large" />}>
       <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
-        <Stack screenOptions={{ headerShown: false }} />
+        <AppContent />
       </SQLiteProvider>
     </Suspense>
   );
+}
+
+function AppContent() {
+  return <Stack screenOptions={{ headerShown: false }} />;
 }

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,43 +1,11 @@
-import migrations from "@/db/drizzle/migrations";
-import { drizzle } from "drizzle-orm/expo-sqlite";
-import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
+import DatabaseProvider from "@/db/provider";
 import { Stack } from "expo-router";
-import { SQLiteProvider, openDatabaseSync } from "expo-sqlite";
-import { Suspense } from "react";
-import { ActivityIndicator, Text } from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
-
-const DATABASE_NAME = "master.db";
 
 export default function RootLayout() {
-  const expoDb = openDatabaseSync(DATABASE_NAME);
-
-  const db = drizzle(expoDb);
-
-  const { success, error } = useMigrations(db, migrations);
-
-  if (error) {
-    return (
-      <SafeAreaView>
-        <Text style={{ fontSize: 32 }}>Migration error: {error.message}</Text>
-      </SafeAreaView>
-    );
-  }
-
-  if (!success) {
-    return (
-      <SafeAreaView>
-        <ActivityIndicator size="large" />
-      </SafeAreaView>
-    );
-  }
-
   return (
-    <Suspense fallback={<ActivityIndicator size="large" />}>
-      <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
-        <AppContent />
-      </SQLiteProvider>
-    </Suspense>
+    <DatabaseProvider>
+      <AppContent />
+    </DatabaseProvider>
   );
 }
 

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -7,7 +7,7 @@ import { Suspense } from "react";
 import { ActivityIndicator, Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
-const DATABASE_NAME = "test2.db";
+const DATABASE_NAME = "master.db";
 
 export default function RootLayout() {
   const expoDb = openDatabaseSync(DATABASE_NAME);

--- a/src/app/data-recovery.tsx
+++ b/src/app/data-recovery.tsx
@@ -1,0 +1,144 @@
+import ScreenHeading from "@/components/ScreenHeading";
+import * as SQLite from "expo-sqlite";
+import { useEffect, useState } from "react";
+import { Text } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+const OLD_DATABASE_NAME = "test2.db";
+
+type MigrationResult = {
+  state: "Running" | "Error" | "Success";
+  message: string;
+};
+
+export default function DataRecoveryScreen() {
+  const expoDb = SQLite.useSQLiteContext();
+  const [result, setResult] = useState<MigrationResult>({
+    state: "Running",
+    message: "please wait...",
+  });
+
+  useEffect(() => {
+    async function runMigration() {
+      await migrateTestDbToMasterDb(expoDb);
+    }
+
+    runMigration()
+      .then(() => {
+        setResult({
+          state: "Success",
+          message: "Done!! PROBLEM FIXED",
+        });
+      })
+      .catch((e) => {
+        setResult({
+          state: "Error",
+          message: e.toString(),
+        });
+      });
+  }, []);
+
+  return (
+    <SafeAreaView
+      style={{
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        padding: 20,
+        gap: 10,
+      }}
+    >
+      <ScreenHeading title="Data Recovery" />
+
+      <Text style={{ fontSize: 16 }}>{result.state}</Text>
+      <Text style={{ color: result.state === "Error" ? "#ef1713" : "#1aadf1" }}>
+        {result.message}
+      </Text>
+    </SafeAreaView>
+  );
+}
+
+export async function migrateTestDbToMasterDb(expoDb: SQLite.SQLiteDatabase) {
+  let oldDb: SQLite.SQLiteDatabase | undefined = undefined;
+
+  try {
+    oldDb = await SQLite.openDatabaseAsync(OLD_DATABASE_NAME);
+
+    // Verify passwords table exists
+    const tableExists = await oldDb.getFirstAsync(
+      `SELECT name
+          FROM sqlite_master
+          WHERE type='table'
+          AND name='passwords'`,
+    );
+
+    if (!tableExists) {
+      await oldDb.closeAsync();
+      await SQLite.deleteDatabaseAsync(OLD_DATABASE_NAME);
+      return;
+    }
+
+    const rows = await oldDb.getAllAsync<{
+      domain: string | null;
+      username: string | null;
+      password: string;
+      notes: string | null;
+      url: string | null;
+      created_at: number;
+      updated_at: number;
+    }>(
+      `SELECT
+          domain,
+          username,
+          password,
+          notes,
+          url,
+          created_at,
+          updated_at
+       FROM passwords`,
+    );
+    await expoDb.withTransactionAsync(async () => {
+      const insertStatement = await expoDb.prepareAsync(`
+        INSERT INTO passwords (
+          domain,
+          username,
+          password,
+          notes,
+          url,
+          created_at,
+          updated_at
+        )
+        VALUES (
+          $domain,
+          $username,
+          $password,
+          $notes,
+          $url,
+          $created_at,
+          $updated_at
+        )
+      `);
+
+      try {
+        for (const row of rows) {
+          await insertStatement.executeAsync({
+            $domain: row.domain,
+            $username: row.username,
+            $password: row.password,
+            $notes: row.notes,
+            $url: row.url,
+            $created_at: row.created_at,
+            $updated_at: row.updated_at,
+          });
+        }
+      } finally {
+        await insertStatement.finalizeAsync();
+      }
+    });
+  } catch (error) {
+    console.error("Migration failed:", error);
+    throw error;
+  } finally {
+    oldDb?.closeAsync();
+  }
+}

--- a/src/app/get-back-passwords.tsx
+++ b/src/app/get-back-passwords.tsx
@@ -1,7 +1,7 @@
 import ScreenHeading from "@/components/ScreenHeading";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Directory, File, Paths } from "expo-file-system";
 import * as SQLite from "expo-sqlite";
+import AsyncStorage from "expo-sqlite/kv-store";
 import { useEffect, useState } from "react";
 import { Button, Platform, Text } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
@@ -87,13 +87,14 @@ export default function GetBackPasswordsScreen() {
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
+        padding: 20,
         gap: 10,
       }}
     >
       <ScreenHeading title="GetBack Data" />
       <Text
         style={{
-          color: taskStatus.isError ? "#ef1713" : "#1aadf1",
+          color: taskStatus.isError ? "#d1120f" : "#06a3eb",
           fontSize: 16,
         }}
       >

--- a/src/app/settings.tsx
+++ b/src/app/settings.tsx
@@ -31,6 +31,11 @@ export default function SettingsScreen() {
           href={"/get-back-passwords"}
           text="GetBack Passwords From v2"
         />
+        <LinkButton
+          style={{ color: "#0257c1", textAlign: "center" }}
+          href={"/data-recovery"}
+          text="Data Recovery"
+        />
       </View>
 
       <View

--- a/src/db/provider.tsx
+++ b/src/db/provider.tsx
@@ -1,0 +1,45 @@
+import { drizzle } from "drizzle-orm/expo-sqlite";
+import { useMigrations } from "drizzle-orm/expo-sqlite/migrator";
+import { openDatabaseSync, SQLiteProvider } from "expo-sqlite";
+import { Suspense, type PropsWithChildren } from "react";
+import { ActivityIndicator, Text } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import migrations from "./drizzle/migrations";
+
+export const DATABASE_NAME = "master.db";
+
+export default function DatabaseProvider({ children }: PropsWithChildren) {
+  const expoDb = openDatabaseSync(DATABASE_NAME);
+
+  const db = drizzle(expoDb);
+
+  const { success, error } = useMigrations(db, migrations);
+
+  if (error) {
+    return (
+      <SafeAreaView
+        style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
+      >
+        <Text style={{ fontSize: 32 }}>Migration error: {error.message}</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (!success) {
+    return (
+      <SafeAreaView
+        style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
+      >
+        <ActivityIndicator size="large" />
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <Suspense fallback={<ActivityIndicator size="large" />}>
+      <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
+        {children}
+      </SQLiteProvider>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
# Changes Made

- keep my data prompt on uninstall.
- move react-native-async-storage dependency to expo-sqlite-key-value-store
- fix database name to `master.db`.
- add a data recovery method in troubleshooting.
- refactor the db code.

## Breaking Changes / Compatibility

**Yes, it has a breaking change that is fixable**. As the database name change, the data will be lost, or in better words became undiscoverable. to retrieve it, use Setting -> Troubleshooting -> Data Recovery.

