### PR TITLE
fix(settings): correct Telegram social link

### DIFF
--- a/src/app/(tabs)/(settings)/settings.tsx
+++ b/src/app/(tabs)/(settings)/settings.tsx
@@ -273,7 +273,7 @@ export default function SettingsScreen() {
                 darkModeColor="#3a424b"
               />
               <LinkIconButton
-                href="mailto:jeeldobariya38@gmail.com"
+                href="https://t.me/passcodescommunity"
                 icon={({ size, color }) => (
                   <FontAwesome6
                     name="telegram"


### PR DESCRIPTION
## Overview

Fix the incorrect Telegram social button in the Settings screen.

The Telegram icon was mistakenly configured to open the project's email address instead of the official Telegram link. This PR updates the button to point to the correct destination, restoring the expected behavior.

## Changes

- Replace the incorrect `mailto:` link with the official Telegram URL.
- Restore the intended navigation for the Telegram social button.
- No UI or behavioral changes outside of this fix.

## Type of Change

- 🐛 Bug fix (non-breaking change)